### PR TITLE
V0.1.4.0

### DIFF
--- a/Distribution/GameData/JSI/JSIAdvTransparentPods/ChangeLog.txt
+++ b/Distribution/GameData/JSI/JSIAdvTransparentPods/ChangeLog.txt
@@ -1,4 +1,10 @@
-﻿V0.1.3.0 (now released as a seperate mod/repro from Raster Prop Monitor)
+﻿V0.1.4.0
+Added swappable/multiple Depth Mask Shader support. See the WIKI page for details.
+Automatically enable/disable the TransparentPod setting (part right click menu) if the IVA is obstructed by something else in front of it.
+TransparentPod setting in the part right click menu will now display "Obstructed" in this scenario ONLY if it was set to "ON". If it is set to
+"OFF" or "AUTO" it will remain locked in that state whilst obstructed.
+Improved Portrait Camera handling.
+V0.1.3.0 (now released as a seperate mod/repro from Raster Prop Monitor)
 Fixed broken Transparent Shader and Opaque Shader swapping functionality.
 Fixed camera jitters/lag on Transparent IVAs that are not part of the active vessel in flight.
 Fixed Portrait Cameras when EVA from vessel.

--- a/Distribution/GameData/JSI/JSIAdvTransparentPods/JSIAdvTransparentPods.version
+++ b/Distribution/GameData/JSI/JSIAdvTransparentPods/JSIAdvTransparentPods.version
@@ -2,8 +2,8 @@
 "NAME":"JSIAdvTransparentPods",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=287",
 "DOWNLOAD":"http://spacedock.info/mod/598/JSI%20Advanced%20Transparent%20Pods",
-"VERSION":{"MAJOR":0,"MINOR":1,"PATCH":3,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":1,"PATCH":1},
-"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":1,"PATCH":0},
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":1,"PATCH":1}
+"VERSION":{"MAJOR":0,"MINOR":1,"PATCH":4,"BUILD":0},
+"KSP_VERSION":{"MAJOR":1,"MINOR":1,"PATCH":2},
+"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":1,"PATCH":1},
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":1,"PATCH":2}
 }

--- a/JSITransparentPods/JSIAdvTransparentPods.csproj
+++ b/JSITransparentPods/JSIAdvTransparentPods.csproj
@@ -86,7 +86,19 @@
     <Content Include="LocalDev\pdb2mdb_exe.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="PostBuildMacros">
+    <GetAssemblyIdentity AssemblyFiles="$(TargetPath)">
+      <Output TaskParameter="Assemblies" ItemName="Targets" />
+    </GetAssemblyIdentity>
+    <ItemGroup>
+      <VersionNumber Include="@(Targets->'%(Version)')" />
+    </ItemGroup>
+  </Target>
   <PropertyGroup>
+  <PostBuildEventDependsOn>
+    $(PostBuildEventDependsOn);
+    PostBuildMacros;
+  </PostBuildEventDependsOn>
     <PostBuildEvent>set /p KSP_DIR=&lt;"$(ProjectDir)LocalDev\ksp_dir.txt"
 
 set /p MONO_EXE_DIR=&lt;"$(ProjectDir)LocalDev\mono_exe.txt"
@@ -105,9 +117,9 @@ xcopy "$(TargetDir)$(ProjectName).dll.mdb" "$(ProjectDir)Distribution\GameData\J
 where /q %25ZA_DIR%25:7za.exe
 if %25ERRORLEVEL%25 == 1 (  echo Cannot find 7-zip to package build) else (  echo Packaging build  ) 
 
-if exist "$(SolutionDir)$(ProjectName).zip" del "$(SolutionDir)$(ProjectName).zip"   
-%25ZA_DIR%257za.exe a -tzip "$(SolutionDir)$(ProjectName).zip" "$(ProjectDir)Distribution\GameData" 
-%25ZA_DIR%257za.exe d -r "$(SolutionDir)$(ProjectName).zip" "*.ddsified" "*.pdb" "*.mdb" "*.xcf" "*.blend" "thumbs.db"
+if exist "$(SolutionDir)$(ProjectName)_V@(VersionNumber).zip" del "$(SolutionDir)$(ProjectName)_V@(VersionNumber).zip"   
+%25ZA_DIR%257za.exe a -tzip "$(SolutionDir)$(ProjectName)_V@(VersionNumber).zip" "$(ProjectDir)Distribution\GameData" 
+%25ZA_DIR%257za.exe d -r "$(SolutionDir)$(ProjectName)_V@(VersionNumber).zip" "*.ddsified" "*.pdb" "*.mdb" "*.xcf" "*.blend" "thumbs.db"
 xcopy /E /Y "$(ProjectDir)Distribution\GameData" "%25KSP_DIR%25\GameData"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/JSITransparentPods/JSIAdvTransparentPods.csproj.user
+++ b/JSITransparentPods/JSIAdvTransparentPods.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ProjectView>ProjectFiles</ProjectView>
-  </PropertyGroup>
-</Project>

--- a/JSITransparentPods/Properties/AssemblyInfo.cs
+++ b/JSITransparentPods/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.3.0")]
-[assembly: AssemblyFileVersion("0.1.3.0")]
+[assembly: AssemblyVersion("0.1.4.0")]
+[assembly: AssemblyFileVersion("0.1.4.0")]


### PR DESCRIPTION
Added swappable/multiple Depth Mask Shader support. See the WIKI page
for details.
Automatically enable/disable the TransparentPod setting (part right
click menu) if the IVA is obstructed by something else in front of it.
TransparentPod setting in the part right click menu will now display
"Obstructed" in this scenario ONLY if it was set to "ON". If it is set
to
"OFF" or "AUTO" it will remain locked in that state whilst obstructed.
Improved Portrait Camera handling.